### PR TITLE
Runtime error fixes

### DIFF
--- a/IncomeOnOddOrEvenTerritories/Client_SaveConfigureUI.lua
+++ b/IncomeOnOddOrEvenTerritories/Client_SaveConfigureUI.lua
@@ -6,7 +6,7 @@ function Client_SaveConfigureUI(alert)
 
     if (Mod.Settings.UsePercent) then
         local percentToRemove = percentSlider.GetValue();
-        if (percentToRemove <= 0  or percentToRemove > 100 or percentToRemove==nil) then 
+        if (percentToRemove==nil or percentToRemove <= 0 or percentToRemove > 100) then 
             alert('% to remove not set properly')
         else
             Mod.Settings.PercentToRemove = percentToRemove;  -- TO DO : round this properly 

--- a/PressThisButton/Client_SaveConfigureUI.lua
+++ b/PressThisButton/Client_SaveConfigureUI.lua
@@ -4,7 +4,7 @@ function Client_SaveConfigureUI(alert)
     Mod.Settings.PopupWarning = warningToggle.GetIsChecked();
     
     -- check if value is within bounds
-    if (Mod.Settings.ReducePercent < 1 or Mod.Settings.ReducePercent > 100 or Mod.Settings.ReducePercent==nil) then 
+    if (Mod.Settings.ReducePercent==nil or Mod.Settings.ReducePercent < 1 or Mod.Settings.ReducePercent > 100) then 
         alert('"Reduce player income by" must be set between 1 and 100'); 
     end
 end

--- a/VoteToEnd/Client_SaveConfigureUI.lua
+++ b/VoteToEnd/Client_SaveConfigureUI.lua
@@ -4,13 +4,13 @@ function Client_SaveConfigureUI(alert)
     local turns = turnsInputField.GetValue();
     
     -- check if values are within bounds
-    if (percents <= 50 or percents > 100 or percents==nil) then 
+    if (percents==nil or percents <= 50 or percents > 100) then 
         alert('"% of players" must be set between 51 and 100'); 
     else 
         Mod.Settings.PercentPlayers = percents
     end
 
-    if (turns < 1 or turns==nil) then
+    if (turns==nil or turns < 1) then
        alert('"Number of turns" must be set') 
     else
         Mod.Settings.WarningTurns = turns


### PR DESCRIPTION
In Client_SaveConfigureUI nil check should be the first thing to check for otherwise checking for it will be ineffective against the event of a nil value and causing an error due to attempting to perform arithmetic on a nil value